### PR TITLE
Add cross-origin headers to all responses

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -243,6 +243,27 @@ func TestHandleInavalidParams(t *testing.T) {
 
 }
 
+func TestAddCORSHeaders(t *testing.T) {
+	ts := httptest.NewServer(addCORSHeaders(http.HandlerFunc(http.NotFound)))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	for key, want := range map[string]string{
+		"Access-Control-Allow-Headers": "Accept, Authorization, Content-Type, Origin",
+		"Access-Control-Allow-Methods": "GET, POST, DELETE",
+		"Access-Control-Allow-Origin":  "*",
+	} {
+		if have := res.Header.Get(key); have != want {
+			t.Errorf("want %s, have %s", want, have)
+		}
+	}
+}
+
 type mockFile struct {
 	buffer *bytes.Buffer
 	data   []byte


### PR DESCRIPTION
This is an attempt at fixing #17. This is the first time I've ever looked at go code, so I just copied what I could find and hoped for the best, and I'm really not sure if what I've written is idiomatic or not. Also, there's no tests, sorry.

Issue #17:
>When trying to access the ent api from a browser, using XHR, same origin policy prevents the requests from being successful.

>To remedy, ent should respond to all requests, including OPTIONS requests with the headers:

```
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, DELETE
Access-Control-Allow-Headers: Accept, Authorization, Content-Type, Origin
```